### PR TITLE
Add runtime and engine specs

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -15,7 +15,7 @@ environment_variables:
 engine_images:
   - image_name: engine
     tags:
-      - 14
+      - 14-cml-2021.05-1
 
 runtimes:
   - editor: Workbench

--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -12,6 +12,16 @@ environment_variables:
     description: "Allow Python to find scripts directory when run as CLI"
     prompt_user: false
 
+engine_images:
+  - image_name: engine
+    tags:
+      - 14
+
+runtimes:
+  - editor: Workbench
+    kernel: Python 3.6
+    edition: Standard
+
 tasks:
   - type: run_session
     name: Install Dependencies

--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -11,6 +11,11 @@ environment_variables:
     default: "/home/cdsw"
     description: "Allow Python to find scripts directory when run as CLI"
     prompt_user: false
+  
+  MLFLOW_TRACKING_URI:
+    default: ""
+    description: "URI of the tracking server. Leave blank to run locally."
+    prompt_user: false
 
 engine_images:
   - image_name: engine
@@ -21,6 +26,7 @@ runtimes:
   - editor: Workbench
     kernel: Python 3.6
     edition: Standard
+    version: 2021.09
 
 tasks:
   - type: run_session

--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -13,22 +13,13 @@ environment_variables:
     prompt_user: false
 
 tasks:
-  - type: create_job
+  - type: run_session
     name: Install Dependencies
     entity_label: install_dependencies
     script: cml/install_dependencies.py
-    arguments: None
-    cpu: 1
-    memory: 2
-    short_summary: Create a job to install project dependencies.
-    environment:
-      TASK_TYPE: CREATE/RUN_JOB
     kernel: python3
-    
-  - type: run_job
-    entity_label: install_dependencies
-    short_summary: Run the install dependencies job.
-    long_summary: Run the install dependencies job.
+    memory: 2
+    cpu: 1
 
   - type: create_job
     name: Train KNeighbors


### PR DESCRIPTION
This PR adds a runtime and engine spec to the project declaration. Works on CDP public for both.