### PR TITLE
Upgrade AMP to Python 3.9

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -2,9 +2,8 @@ name: MLFlow Tracking
 description: Instrumenting some scikit-learn models with MLFLow for experiment tracking.
 author: Cloudera Inc.
 specification_version: 1.0
-prototype_version: 1.0
-date: "2020-12-09"
-api_version: 1
+prototype_version: 2.0
+date: "2022-03-28"
 
 environment_variables:
   PYTHONPATH:
@@ -18,13 +17,8 @@ environment_variables:
 
 runtimes:
   - editor: Workbench
-    kernel: Python 3.6
+    kernel: Python 3.9
     edition: Standard
-
-engine_images:
-  - image_name: engine
-    tags:
-      - 14
 
 tasks:
   - type: create_job
@@ -37,7 +31,6 @@ tasks:
     short_summary: Create a job to install project dependencies.
     environment:
       TASK_TYPE: CREATE/RUN_JOB
-    kernel: python3
     
   - type: run_job
     entity_label: install_dependencies
@@ -54,7 +47,6 @@ tasks:
     short_summary: Create a training job for a k-nearest neighbors classifier.
     environment:
       TASK_TYPE: CREATE/RUN_JOB
-    kernel: python3
     
   - type: run_job
     entity_label: train_kneighbors
@@ -71,7 +63,6 @@ tasks:
     short_summary: Create a training job for a random forest classifier.
     environment:
       TASK_TYPE: CREATE/RUN_JOB
-    kernel: python3
     
   - type: run_job
     entity_label: train_random_forest
@@ -85,4 +76,3 @@ tasks:
     short_summary: Launch the MLFlow UI application
     environment_variables:
       TASK_TYPE: START_APPLICATION
-    kernel: python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn==0.23.2
-mlflow==1.12.1
+scikit-learn
+mlflow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn
-mlflow
+scikit-learn==1.0.2
+mlflow==1.24.0


### PR DESCRIPTION
- Resolves [DSE-20695 ](https://jira.cloudera.com/browse/DSE-20695)
- Tested on CML Public Cloud successfully (see screenshots)
- No backwards compatibility issues found with Python 3.9 during testing

**CML Public Cloud  Testing Screenshots:**

<img width="419" alt="Screen Shot 2022-03-28 at 12 46 07 PM" src="https://user-images.githubusercontent.com/1268702/160486815-ac40dcae-157b-426b-bd6c-ff01c8daae78.png">

<img width="1538" alt="Screen Shot 2022-03-28 at 12 46 30 PM" src="https://user-images.githubusercontent.com/1268702/160486830-de55118c-3a9f-40ca-8279-64822f9b9108.png">

Model screen never pulled up, but the Tracking URI was never configured.

<img width="1448" alt="Screen Shot 2022-03-28 at 12 46 38 PM" src="https://user-images.githubusercontent.com/1268702/160486854-1b3e3a30-8eab-4690-a04b-d460b29e68f7.png">


